### PR TITLE
Update pr-replay code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To get started, see [TUTORIAL.md](./TUTORIAL.md)
 ## Evaluation
 
 This repo also includes a tool to evaluate the PR Reviewer responses. This tool will replay each PR history in a target GitHub repository, 
-adding in the PR Reviewer comments, and then using "LLM-as-a-judge" to evaluate the PR Reviewer feedback. To use this tool, refer to the[Evaluation Guide](eval/README.md).
+adding in the PR Reviewer comments, and then using "LLM-as-a-judge" to evaluate the PR Reviewer feedback. To use this tool, refer to the [Evaluation Guide](eval/README.md).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,8 @@ To get started, see [TUTORIAL.md](./TUTORIAL.md)
 
 ## Evaluation
 
-This repo also includes a tool to evaluate the PR Reviewer responses. This tool will replay the entire PR 
-history for a GitHub repository, adding in the PR Reviewer comments for each commit, and then using 
-"LLM-as-a-judge" to evaluate the PR Reviewer feedback. To use this tool, refer to the 
-[Evaluation Guide](eval/README.md).
+This repo also includes a tool to evaluate the PR Reviewer responses. This tool will replay each PR history in a target GitHub repository, 
+adding in the PR Reviewer comments, and then using "LLM-as-a-judge" to evaluate the PR Reviewer feedback. To use this tool, refer to the[Evaluation Guide](eval/README.md).
 
 ## Roadmap
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -5,7 +5,7 @@ This eval/ subdirectory contains a tool designed to **evaluate the performance o
 ### How It Works
 
 1. **Repository History Replay:** The tool extracts the historical pull requests (PRs) from a reference repository and replays the base commit and final merge commit within each PR.
-2. **Automated Review:** For each replayed PR, the Multi-Agent PR Reviewer provides an automated review .
+2. **Automated Review:** For each replayed PR, the Multi-Agent PR Reviewer provides an automated review.
 3. **Quality Assessment:** A Large Language Model (LLM) acts as an independent judge to evaluate the quality of the reviews provided by the Multi-Agent system.
 4. **Report Generation:** The results are summarized into a report, giving a performance rating for the PR reviewer.
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -4,8 +4,8 @@ This eval/ subdirectory contains a tool designed to **evaluate the performance o
 
 ### How It Works
 
-1. **Repository History Replay:** The tool extracts the historical pull requests (PRs) from a reference repository and replays every commit within each PR.
-2. **Automated Review:** For each replayed PR, the Multi-Agent PR Reviewer provides an automated review.
+1. **Repository History Replay:** The tool extracts the historical pull requests (PRs) from a reference repository and replays the base commit and final merge commit within each PR.
+2. **Automated Review:** For each replayed PR, the Multi-Agent PR Reviewer provides an automated review .
 3. **Quality Assessment:** A Large Language Model (LLM) acts as an independent judge to evaluate the quality of the reviews provided by the Multi-Agent system.
 4. **Report Generation:** The results are summarized into a report, giving a performance rating for the PR reviewer.
 

--- a/eval/pr_replay.py
+++ b/eval/pr_replay.py
@@ -248,7 +248,7 @@ def main(config_file, **kwargs):
         sys.exit(1)
     obj = AlfredReviewGeneration(config_file)
     alfred_pr_replay = obj.generateAlfredReview()
-    json.dump(alfred_pr_replay, open(f"alfred_cisco_eti_pr_replay_{datetime.now().strftime("%d-%b-%Y")}.json", "w"))
+    json.dump(alfred_pr_replay, open(f"pr_replay_{datetime.now().strftime("%d-%b-%Y")}.json", "w"))
 
 
 if __name__ == '__main__':

--- a/eval/pr_replay.py
+++ b/eval/pr_replay.py
@@ -189,7 +189,7 @@ class AlfredReviewGeneration:
                                 results['AlfredPRs'].append(
                                     {"pr_number": pr_number,
                                      "originalpr_url": values["url"],
-                                     "prreviewer_url": "No PRcoach Replay",
+                                     "prreviewer_url": "No Alfred PR Replay",
                                      "PR_replay_Status": "No Merged Code Directory Present",
                                      "Commit_files": []
                                      }
@@ -204,7 +204,7 @@ class AlfredReviewGeneration:
                             results['AlfredPRs'].append(
                                 {"pr_number": pr_number,
                                  "originalpr_url": values["url"],
-                                 "prreviewer_url": "No PRcoach Replay",
+                                 "prreviewer_url": "No Alfred PR Replay",
                                  "PR_replay_Status": "No Base Code Directory Present",
                                  "Commit_files": []
                                  }

--- a/eval/pr_replay.py
+++ b/eval/pr_replay.py
@@ -162,7 +162,7 @@ class AlfredReviewGeneration:
                             self.createBranch("Pr_base_{}".format(pr_number), f"PR_changed_{pr_number}")
 
                             # Get final merged contents
-                            if os.path.isfile(final_merged_directory):
+                            if os.path.isdir(final_merged_directory):
                                 final_commit_contents = self.readContentsFromDirectory(final_merged_directory)
                                 self.createCommit(final_commit_contents, f"PR_changed_{pr_number}", "merged_content")
                                 pr = self.createPR("Pr_base_{}".format(pr_number), f"PR_changed_{pr_number}", title,

--- a/eval/pr_replay.py
+++ b/eval/pr_replay.py
@@ -241,7 +241,7 @@ class AlfredReviewGeneration:
 
 def main(config_file, **kwargs):
     """
-    python3 pr_replay.py --config replay_config.yaml
+    python3 pr_replay.py --config_file configs/replay_config.yaml
     """
     if not os.path.exists(config_file):
         print(f"Config file {config_file} does not exist.")


### PR DESCRIPTION
# Description
Currently, PR replay  runs Alfred review after every commit. This is causing repetitive files being added with different names and resulting in misleading responses.

Sample test PR:

> with old PR replay code:
> [(https://github.com/Anusha-1209/Cisco-ETI-PRReplay/pull/170)]
> With the change
> [(https://github.com/Anusha-1209/TofuPRReplay/pull/13)]

Solution:
In order to avoid this discrepancy, we are running Alfred review only once one the merged code change.
 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/cisco-outshift-ai-agents/tf-pr-review-agntcy-multi-agent/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
