### PR TITLE
fix for terraform init issue

### DIFF
--- a/src/graphs/nodes/static_analyzer.py
+++ b/src/graphs/nodes/static_analyzer.py
@@ -110,8 +110,8 @@ class StaticAnalyzer:
             )
             tf_validate_stdout = ""
             tf_validate_stderr = ""
-            lint_stdout = ""
-            lint_stderr = ""
+            tf_lint_stdout = ""
+            tf_lint_stderr = ""
             if tf_init_out.returncode == 0:
                 # The tf_init established the providers and modules folder successfully
                 tf_validate_out = run(
@@ -130,8 +130,8 @@ class StaticAnalyzer:
                 )
                 tf_validate_stdout = tf_validate_out.stdout
                 tf_validate_stderr = tf_validate_out.stderr
-                lint_stdout = tflint_out.stdout
-                lint_stderr = tflint_out.stderr
+                tf_lint_stdout = tflint_out.stdout
+                tf_lint_stderr = tflint_out.stderr
         except CalledProcessError as e:
             log.error(f"Error while running static checks: {e.stderr}")
             return {}
@@ -149,15 +149,15 @@ class StaticAnalyzer:
                 tf_init_error = modifyresponse(file_rename_map, tf_init_out.stderr)
                 tf_validate_output = modifyresponse(file_rename_map, tf_validate_stdout)
                 tf_validate_error = modifyresponse(file_rename_map, tf_validate_stderr)
-                tf_lint_output = modifyresponse(file_rename_map, lint_stdout)
-                tf_lint_error = modifyresponse(file_rename_map, lint_stderr)
+                tf_lint_output = modifyresponse(file_rename_map, tf_lint_stdout)
+                tf_lint_error = modifyresponse(file_rename_map, tf_lint_stderr)
             else:
                 tf_init_output = tf_init_out.stdout
                 tf_init_error = tf_init_out.stderr
                 tf_validate_output = tf_validate_stdout
                 tf_validate_error = tf_validate_stderr
-                tf_lint_output = lint_stdout
-                tf_lint_error = lint_stderr
+                tf_lint_output = tf_lint_stdout
+                tf_lint_error = tf_lint_stderr
 
             staticanalyzerinput = StaticAnalyzerInput(
                 tf_init_stdout=tf_init_output,

--- a/src/graphs/nodes/static_analyzer.py
+++ b/src/graphs/nodes/static_analyzer.py
@@ -107,6 +107,22 @@ class StaticAnalyzer:
                 stderr=PIPE,
                 text=True,
             )
+            if tf_validate_out.returncode == 1 and "terraform init" in tf_validate_out.stderr:
+                # If the directory expects terraform init to run.
+                run(
+                    ["terraform", "init", "-backend=false"],
+                    check=True,
+                    cwd=output_folder,
+                    capture_output=True,
+                    text=True,
+                )
+                tf_validate_out = run(
+                    ["terraform", "validate", "-no-color"],
+                    cwd=output_folder,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    text=True,
+                )
             lint_stdout, lint_stderr = "", ""
             # If terraform validate passes, run tflint
             if tf_validate_out.returncode == 0:

--- a/src/utils/models.py
+++ b/src/utils/models.py
@@ -52,6 +52,8 @@ class ContextFile(BaseModel):
 
 class StaticAnalyzerInput(BaseModel):
 
+    tf_init_stderr: str = Field(description="This is the stderr output for running terraform init --backend=false")
+    tf_init_stdout: str = Field(description="This is the stdout output for running terraform init --backend=false")
     tf_validate_out_stderr: str = Field(description="This is the stderr output after running terraform validate -no-color")
     tf_validate_out_stdout: str = Field(description="This is the stdout output after running terraform validate -no-color")
     tflint_output_stderr: str = Field(description="This is the stderr output after running tflint --format=compact --recursive")


### PR DESCRIPTION
# Description
While running in ACP mode or local mode we are sometimes getting "Run Terraform Init" command.

#Current logic

We run "terraform init" only if the terraform validate is successful since it is a heavy command.
The issue is in ACP mode sometimes. the "terraform init" is not ran which is causing "terraform validate" to fail.
#Our fix

1. run Terraform init before Terraform Validate
2. Capture terraform init output & error along with the other output and error
3. Pass the terraform init output and error to the static analyzer output

Confluence: https://cisco-eti.atlassian.net/wiki/spaces/alfred/pages/1353548117/Terraform+Init+Issue+Analysis

Testing PR:
824 - https://github.com/Anusha-1209/PR_Replay_Without_Refactored_Code/pull/50
826 - https://github.com/Anusha-1209/PR_Replay_Without_Refactored_Code/pull/49



## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/cisco-outshift-ai-agents/tf-pr-review-agntcy-multi-agent/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
